### PR TITLE
Fixed composer global require

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ where x.y.z is the latest [release tag](https://github.com/orocrm/platform-appli
 and install [fxpio/composer-asset-plugin][5] plugin for it:
 
 ```bash
-    composer global require "fxp/composer-asset-plugin:~1.2"
+    composer global require "fxp/composer-asset-plugin:dev-master"
 ```
 
 - Install [Node.js][6].


### PR DESCRIPTION
I was getting a composer error Could not parse version constraint >=~2: Invalid version string "~2"
Found a fix as per https://github.com/fxpio/composer-asset-plugin/issues/129#issuecomment-125917167